### PR TITLE
fix: fallback reset neo4j when credentials drift

### DIFF
--- a/deploy/deploy-local.sh
+++ b/deploy/deploy-local.sh
@@ -672,6 +672,24 @@ reset_qdrant_data() {
   esac
 }
 
+reset_neo4j_auth_and_data() {
+  warn "Neo4j password mismatch detected; resetting local Neo4j auth and data"
+  if [ "$DRY_RUN" = true ]; then
+    log "  [dry-run] would stop Neo4j and clear /var/lib/neo4j/data/databases/*, /var/lib/neo4j/data/transactions/*, and /var/lib/neo4j/data/dbms/auth*"
+    return 0
+  fi
+
+  if systemd_unit_exists nukara-neo4j-adapter; then
+    systemctl stop nukara-neo4j-adapter 2>/dev/null || true
+  fi
+  systemctl stop neo4j 2>/dev/null || true
+  rm -rf /var/lib/neo4j/data/databases/*
+  rm -rf /var/lib/neo4j/data/transactions/*
+  rm -rf /var/lib/neo4j/data/dbms/*
+  mkdir -p /var/lib/neo4j/data/databases /var/lib/neo4j/data/transactions /var/lib/neo4j/data/dbms
+  chown -R neo4j:neo4j /var/lib/neo4j/data 2>/dev/null || true
+}
+
 reset_neo4j_data() {
   [ "${NUKARA_MEMORY_INFRA_ENABLED:-true}" = "true" ] || return 0
 
@@ -689,7 +707,10 @@ reset_neo4j_data() {
     return 0
   }
 
-  wait_for_neo4j_ready 30
+  wait_for_neo4j_ready 30 || {
+    reset_neo4j_auth_and_data
+    return 0
+  }
   cypher-shell \
     -a "bolt://127.0.0.1:${NUKARA_NEO4J_BOLT_PORT}" \
     -u "${NUKARA_NEO4J_USER}" \

--- a/deploy/lib/memory-infra.sh
+++ b/deploy/lib/memory-infra.sh
@@ -232,7 +232,7 @@ wait_for_neo4j_ready() {
     elapsed=$((elapsed + 2))
   done
 
-  err "Neo4j readiness check failed. Verify NUKARA_NEO4J_PASSWORD matches the installed database password."
+  return 1
 }
 
 install_neo4j_repository() {
@@ -287,7 +287,7 @@ install_neo4j() {
 
   systemctl enable neo4j
   systemctl restart neo4j
-  wait_for_neo4j_ready 90
+  wait_for_neo4j_ready 90 || err "Neo4j readiness check failed. Verify NUKARA_NEO4J_PASSWORD matches the installed database password."
 }
 
 install_memory_infra() {

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -161,6 +161,7 @@ sudo bash deploy/deploy-local.sh --reset-data
 - 交互模式下需要手动输入 `RESET` 确认
 - `--non-interactive` 下不会再二次确认，请谨慎使用
 - `--dry-run --reset-data` 只打印将执行的清理动作，不实际删除数据
+- Neo4j 认证失败时，脚本会自动清空本地 Neo4j data/auth 状态，并在后续安装步骤中按当前配置重新初始化密码与数据库
 
 ### 部署状态
 

--- a/docs/plans/2026-03-07-neo4j-reset-fallback-design.md
+++ b/docs/plans/2026-03-07-neo4j-reset-fallback-design.md
@@ -1,0 +1,23 @@
+# Neo4j Reset Fallback Design
+
+**Problem**
+
+`deploy/deploy-local.sh --reset-data` currently assumes the configured `NUKARA_NEO4J_PASSWORD` can authenticate against the existing local Neo4j instance. On a reused server, the real password may be unknown or drifted from the current deployment config, causing the reset flow to abort before the one-click redeploy can continue.
+
+**Chosen Approach**
+
+1. Keep the current fast path: if Neo4j accepts the configured credentials, clear graph data with Cypher.
+2. If readiness/authentication fails during `--reset-data`, treat it as a local-state mismatch.
+3. Automatically stop Neo4j, wipe local Neo4j data/auth state, and let the later `install_memory_infra` step reinitialize Neo4j with the current deployment password.
+
+**Why This Approach**
+
+- Preserves one-click behavior for dedicated Nukara servers.
+- Avoids requiring the operator to know historic Neo4j credentials.
+- Reuses the existing Neo4j install flow to recreate auth and database state cleanly.
+
+**Validation**
+
+- Extend `scripts/verify_reset_data_flag.sh` to assert the fallback helper and docs exist.
+- Run verification before implementation to confirm failure.
+- Run verification and shell syntax checks after implementation.

--- a/docs/plans/2026-03-07-neo4j-reset-fallback.md
+++ b/docs/plans/2026-03-07-neo4j-reset-fallback.md
@@ -1,0 +1,75 @@
+# Neo4j Reset Fallback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `deploy/deploy-local.sh --reset-data` continue one-click deployment even when the existing local Neo4j password is unknown.
+
+**Architecture:** Keep the current application-data reset behavior for PostgreSQL, Redis, and Qdrant. For Neo4j, first try the configured credentials; if authentication/readiness fails, wipe the local Neo4j data/auth directories and allow the later install step to recreate them with the current deployment password.
+
+**Tech Stack:** Bash, systemd, Neo4j cypher-shell
+
+---
+
+### Task 1: Extend regression verification
+
+**Files:**
+- Modify: `scripts/verify_reset_data_flag.sh`
+
+**Step 1: Write the failing test**
+
+Require the reset-data verification script to assert:
+- a `reset_neo4j_auth_and_data` helper exists
+- `reset_neo4j_data` falls back when Neo4j readiness/auth fails
+- docs mention the fallback behavior
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash scripts/verify_reset_data_flag.sh`
+Expected: FAIL before the fallback is implemented.
+
+### Task 2: Implement Neo4j fallback
+
+**Files:**
+- Modify: `deploy/deploy-local.sh`
+- Modify: `deploy/lib/memory-infra.sh`
+
+**Step 1: Write minimal implementation**
+
+- make `wait_for_neo4j_ready` return non-zero instead of exiting directly
+- keep install-time failure behavior by making the installer call `err` explicitly
+- add a helper that stops Neo4j and clears local data/auth state
+- call that helper from `reset_neo4j_data` when Neo4j does not accept current credentials
+
+**Step 2: Run test to verify it passes**
+
+Run: `bash scripts/verify_reset_data_flag.sh`
+Expected: PASS.
+
+### Task 3: Document one-click server behavior
+
+**Files:**
+- Modify: `docs/deployment-guide.md`
+
+**Step 1: Add fallback note**
+
+Document that during `--reset-data`, a Neo4j auth mismatch causes the script to wipe local Neo4j auth/data and continue with a clean reinitialization.
+
+**Step 2: Re-run verification**
+
+Run: `bash scripts/verify_reset_data_flag.sh`
+Expected: PASS.
+
+### Task 4: Verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run shell checks**
+
+Run: `bash -n deploy/deploy-local.sh deploy/lib/memory-infra.sh scripts/verify_reset_data_flag.sh`
+Expected: exit 0.
+
+**Step 2: Re-run regressions**
+
+Run: `bash scripts/verify_reset_data_flag.sh && bash scripts/verify_deploy_db_permissions.sh`
+Expected: PASS.

--- a/scripts/verify_reset_data_flag.sh
+++ b/scripts/verify_reset_data_flag.sh
@@ -15,8 +15,12 @@ require_line() {
 require_line "deploy/deploy-local.sh" '^[[:space:]]*--reset-data\)'
 require_line "deploy/deploy-local.sh" '--reset-data'
 require_line "deploy/deploy-local.sh" '^confirm_reset_data\(\) \{$'
+require_line "deploy/deploy-local.sh" '^reset_neo4j_auth_and_data\(\) \{$'
 require_line "deploy/deploy-local.sh" '^reset_nukara_data\(\) \{$'
+require_line "deploy/deploy-local.sh" 'Neo4j password mismatch detected; resetting local Neo4j auth and data'
+require_line "deploy/deploy-local.sh" '/var/lib/neo4j/data/dbms/auth\*'
+require_line "deploy/deploy-local.sh" 'wait_for_neo4j_ready 30 \|\|'
 require_line "deploy/deploy-local.sh" 'reset_nukara_data'
-require_line "docs/deployment-guide.md" '`--reset-data`'
+require_line "docs/deployment-guide.md" 'Neo4j 认证失败时'
 
 echo "verify_reset_data_flag: PASS"


### PR DESCRIPTION
## Summary
- make local `--reset-data` recover from unknown Neo4j credentials by wiping local Neo4j auth/data state
- keep install-time Neo4j readiness strict while allowing reset-time fallback behavior
- document the fallback and extend reset-data verification coverage