### PR TITLE
fix: add core schema migration for fresh deploys

### DIFF
--- a/Nukara_Backend/migrations/001_create_core_tables.sql
+++ b/Nukara_Backend/migrations/001_create_core_tables.sql
@@ -1,0 +1,103 @@
+-- migrations/001_create_core_tables.sql
+-- Core application tables required by later migrations.
+
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY,
+    phone VARCHAR(20) UNIQUE NOT NULL,
+    nickname VARCHAR(50) NOT NULL,
+    avatar_url TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS sms_codes (
+    id UUID PRIMARY KEY,
+    phone VARCHAR(20) NOT NULL,
+    purpose VARCHAR(20) NOT NULL,
+    code VARCHAR(10) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    used BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS bots (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    avatar_url TEXT,
+    avatar_base64 TEXT,
+    summary TEXT NOT NULL,
+    speaking_style TEXT NOT NULL,
+    background TEXT NOT NULL,
+    traits JSONB NOT NULL DEFAULT '[]'::jsonb,
+    gender VARCHAR(20) NOT NULL DEFAULT 'unknown',
+    chat_background_style VARCHAR(30) NOT NULL DEFAULT 'lightPaper',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS bot_states (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    bot_id UUID NOT NULL,
+    status_emoji VARCHAR(16) NOT NULL DEFAULT '🙂',
+    status_text VARCHAR(50) NOT NULL DEFAULT '在线',
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, bot_id)
+);
+
+CREATE TABLE IF NOT EXISTS conversations (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    bot_id UUID NOT NULL,
+    last_message TEXT,
+    last_message_at TIMESTAMP,
+    unread_count INT NOT NULL DEFAULT 0,
+    is_proactive_message BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, bot_id)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY,
+    conversation_id UUID NOT NULL,
+    sender_type VARCHAR(10) NOT NULL,
+    content_type VARCHAR(20) NOT NULL,
+    content JSONB NOT NULL,
+    is_proactive BOOLEAN NOT NULL DEFAULT FALSE,
+    emotion_tag VARCHAR(30),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_devices (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    platform VARCHAR(20) NOT NULL,
+    device_token TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, device_token)
+);
+
+CREATE TABLE IF NOT EXISTS user_notification_settings (
+    user_id UUID PRIMARY KEY,
+    proactive_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    dnd_start VARCHAR(5),
+    dnd_end VARCHAR(5),
+    frequency VARCHAR(20) NOT NULL DEFAULT 'normal',
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS proactive_logs (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    bot_id UUID NOT NULL,
+    conversation_id UUID NOT NULL,
+    trigger_type VARCHAR(50) NOT NULL,
+    message TEXT NOT NULL,
+    sent_by_ws BOOLEAN NOT NULL DEFAULT TRUE,
+    sent_by_apns BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/docs/plans/2026-03-07-core-schema-migration-design.md
+++ b/docs/plans/2026-03-07-core-schema-migration-design.md
@@ -1,0 +1,23 @@
+# Core Schema Migration Design
+
+**Problem**
+
+A fresh database created by `deploy/deploy-local.sh --reset-data` runs `Nukara_Backend/migrations/*.sql` in filename order. `004_create_analysis_tables.sql` references `users`, `bots`, and `conversations`, but those core tables are not currently defined anywhere inside `Nukara_Backend/migrations/`. They only exist in `Nukara_Backend/deploy/sql/001_init.sql` or the runtime Go bootstrap schema, so first-time deployments fail before services can even start.
+
+**Chosen Approach**
+
+1. Add a new idempotent migration at the start of `Nukara_Backend/migrations/` that creates the core application tables required by later migrations.
+2. Base it on the existing foundational schema in `Nukara_Backend/deploy/sql/001_init.sql` so deploy-time SQL and migration-time SQL stay aligned.
+3. Keep the deploy script unchanged so any runner that executes `migrations/*.sql` benefits from the fix automatically.
+
+**Why This Approach**
+
+- Fixes the real dependency issue in the migration set rather than patching around it in one script.
+- Preserves existing deployment logic and ordering.
+- Makes empty-database bootstrap deterministic and idempotent.
+
+**Validation**
+
+- Add a regression script that requires a leading core-schema migration file and checks it defines `users`, `bots`, and `conversations`.
+- Run the script before implementation to confirm failure.
+- Run it after implementation, along with existing deploy verification scripts.

--- a/docs/plans/2026-03-07-core-schema-migration.md
+++ b/docs/plans/2026-03-07-core-schema-migration.md
@@ -1,0 +1,52 @@
+# Core Schema Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure empty-database deployments succeed by adding a leading migration that creates the core application tables before dependent migrations run.
+
+**Architecture:** Add a new idempotent SQL migration under `Nukara_Backend/migrations/` that mirrors the foundational tables currently only available in deploy-time bootstrap SQL. Because the deploy script already runs migrations alphabetically, this preserves existing deployment flow while fixing the dependency chain for later migrations.
+
+**Tech Stack:** SQL, Bash
+
+---
+
+### Task 1: Add a failing regression check
+
+**Files:**
+- Create: `scripts/verify_core_schema_migration.sh`
+
+**Step 1: Write the failing test**
+
+Add a shell verification script that asserts:
+- `Nukara_Backend/migrations/001_create_core_tables.sql` exists
+- it defines `users`, `bots`, and `conversations`
+- the analysis migration still references those tables, proving the dependency is now satisfied by earlier migration order
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash scripts/verify_core_schema_migration.sh`
+Expected: FAIL before the new migration exists.
+
+### Task 2: Add the core schema migration
+
+**Files:**
+- Create: `Nukara_Backend/migrations/001_create_core_tables.sql`
+
+**Step 1: Write minimal implementation**
+
+Create an idempotent migration for the foundational tables required by downstream migrations, based on the existing deploy bootstrap schema.
+
+**Step 2: Run test to verify it passes**
+
+Run: `bash scripts/verify_core_schema_migration.sh`
+Expected: PASS.
+
+### Task 3: Verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run verification scripts**
+
+Run: `bash scripts/verify_core_schema_migration.sh && bash scripts/verify_reset_data_flag.sh && bash scripts/verify_deploy_db_permissions.sh`
+Expected: PASS.

--- a/scripts/verify_core_schema_migration.sh
+++ b/scripts/verify_core_schema_migration.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION="$ROOT_DIR/Nukara_Backend/migrations/001_create_core_tables.sql"
+ANALYSIS_MIGRATION="$ROOT_DIR/Nukara_Backend/migrations/004_create_analysis_tables.sql"
+
+[ -f "$MIGRATION" ] || { echo "missing migration: $MIGRATION" >&2; exit 1; }
+
+rg -q 'CREATE TABLE IF NOT EXISTS users' "$MIGRATION" || { echo "users table missing from core migration" >&2; exit 1; }
+rg -q 'CREATE TABLE IF NOT EXISTS bots' "$MIGRATION" || { echo "bots table missing from core migration" >&2; exit 1; }
+rg -q 'CREATE TABLE IF NOT EXISTS conversations' "$MIGRATION" || { echo "conversations table missing from core migration" >&2; exit 1; }
+rg -q 'REFERENCES users\(id\)' "$ANALYSIS_MIGRATION" || { echo "analysis migration no longer references users" >&2; exit 1; }
+rg -q 'REFERENCES bots\(id\)' "$ANALYSIS_MIGRATION" || { echo "analysis migration no longer references bots" >&2; exit 1; }
+rg -q 'REFERENCES conversations\(id\)' "$ANALYSIS_MIGRATION" || { echo "analysis migration no longer references conversations" >&2; exit 1; }
+
+echo "verify_core_schema_migration: PASS"


### PR DESCRIPTION
## Summary
- add a leading core-schema migration so empty databases create foundational tables before dependent migrations run
- keep the deployment migration loop unchanged by fixing the real dependency gap in `Nukara_Backend/migrations`
- add regression verification for the fresh-deploy core schema path