### PR TITLE
fix: stabilize auth memory ids and admin provider ui

### DIFF
--- a/Nukara_Admin_Web/src/App.vue
+++ b/Nukara_Admin_Web/src/App.vue
@@ -31,6 +31,7 @@ const embeddingSaving = ref(false)
 const showCreateProvider = ref(false)
 const createStatus = ref('')
 const selectedSourceId = ref('')
+const expandedProviderId = ref('')
 
 const providers = ref([])
 const rows = ref([])
@@ -53,6 +54,7 @@ const drafts = reactive({})
 const savingByUser = reactive({})
 const savingByProvider = reactive({})
 const testingByProvider = reactive({})
+const providerDrafts = reactive({})
 const providerTestDrafts = reactive({})
 const providerTestReplies = reactive({})
 const newProvider = reactive({
@@ -160,6 +162,50 @@ function ensureProviderTestDraft(provider) {
   return providerTestDrafts[provider.id]
 }
 
+function ensureProviderDraft(provider) {
+  if (!provider?.id) {
+    return {
+      name: '',
+      base_url: '',
+      api_key: '',
+      api_mode: 'chat_completions',
+      models: '',
+      priority: '100',
+    }
+  }
+  if (!providerDrafts[provider.id]) {
+    providerDrafts[provider.id] = {
+      name: provider.name || '',
+      base_url: provider.base_url || '',
+      api_key: provider.api_key || '',
+      api_mode: provider.api_mode || 'chat_completions',
+      models: Array.isArray(provider.models) ? provider.models.join(', ') : '',
+      priority: String(provider.priority ?? 100),
+    }
+  }
+  return providerDrafts[provider.id]
+}
+
+function resetProviderDrafts() {
+  Object.keys(providerDrafts).forEach((key) => {
+    delete providerDrafts[key]
+  })
+  providers.value.forEach((provider) => {
+    providerDrafts[provider.id] = {
+      name: provider.name || '',
+      base_url: provider.base_url || '',
+      api_key: provider.api_key || '',
+      api_mode: provider.api_mode || 'chat_completions',
+      models: Array.isArray(provider.models) ? provider.models.join(', ') : '',
+      priority: String(provider.priority ?? 100),
+    }
+  })
+}
+
+function toggleProviderExpand(providerId) {
+  expandedProviderId.value = expandedProviderId.value === providerId ? '' : providerId
+}
+
 function ensureDraft(user) {
   if (!drafts[user.user_id]) {
     drafts[user.user_id] = {
@@ -252,8 +298,12 @@ async function refreshAll() {
     if (selectedSourceId.value && !providers.value.some((provider) => provider.id === selectedSourceId.value)) {
       selectedSourceId.value = ''
     }
+    if (expandedProviderId.value && !providers.value.some((provider) => provider.id === expandedProviderId.value)) {
+      expandedProviderId.value = ''
+    }
 
     resetDraftsFromRows()
+    resetProviderDrafts()
     statusMessage.value = '数据已刷新。'
   } catch (error) {
     errorMessage.value = error.message
@@ -427,6 +477,56 @@ async function runProviderMessageTest(provider) {
   }
 }
 
+async function saveProvider(provider) {
+  if (!provider?.id || savingByProvider[provider.id]) {
+    return
+  }
+  const draft = ensureProviderDraft(provider)
+  savingByProvider[provider.id] = true
+  errorMessage.value = ''
+  try {
+    await updateProvider(provider.id, {
+      name: draft.name,
+      api_key: draft.api_key,
+      base_url: draft.base_url,
+      api_mode: draft.api_mode,
+      models: draft.models,
+      priority: Number(draft.priority || 100),
+      is_active: provider.is_active,
+    })
+    statusMessage.value = `${provider.name} 配置已保存。`
+    await refreshAll()
+    expandedProviderId.value = provider.id
+  } catch (error) {
+    errorMessage.value = error.message
+  } finally {
+    savingByProvider[provider.id] = false
+  }
+}
+
+async function removeProvider(provider) {
+  if (!provider?.id || savingByProvider[provider.id] || provider.is_active) {
+    return
+  }
+  savingByProvider[provider.id] = true
+  errorMessage.value = ''
+  try {
+    await deleteProvider(provider.id)
+    if (selectedSourceId.value === provider.id) {
+      selectedSourceId.value = ''
+    }
+    if (expandedProviderId.value === provider.id) {
+      expandedProviderId.value = ''
+    }
+    statusMessage.value = `${provider.name} 已删除。`
+    await refreshAll()
+  } catch (error) {
+    errorMessage.value = error.message
+  } finally {
+    savingByProvider[provider.id] = false
+  }
+}
+
 async function saveEmbeddingSettings() {
   if (embeddingSaving.value) {
     return
@@ -535,67 +635,121 @@ onMounted(() => {
             <article
               v-for="provider in providers"
               :key="provider.id"
-              :class="['provider-item-card', { selected: selectedSourceId === provider.id }]"
-              @click="selectedSourceId = selectedSourceId === provider.id ? '' : provider.id"
+              :class="['provider-item-card', {
+                selected: selectedSourceId === provider.id,
+                expanded: expandedProviderId === provider.id,
+              }]"
             >
-              <div class="provider-item-top">
-                <strong>{{ provider.name }}</strong>
-                <span :class="['provider-state', { active: provider.is_active }]">
-                  {{ provider.is_active ? 'Active' : 'Standby' }}
-                </span>
-              </div>
-              <p class="provider-model">
-                {{ Array.isArray(provider.models) && provider.models.length > 0 ? provider.models[0] : '未配置 model' }}
-              </p>
-              <p class="provider-count">{{ providerModeLabel(provider.api_mode) }}</p>
-              <p class="provider-count">{{ providerUsersCount(provider.id) }} 位用户</p>
-              <div class="provider-item-actions">
-                <select
-                  :value="provider.api_mode || 'chat_completions'"
-                  :disabled="creatingProvider || savingByProvider[provider.id]"
-                  @click.stop
-                  @change="changeProviderMode(provider, $event.target.value)"
-                >
-                  <option value="chat_completions">Chat Completions</option>
-                  <option value="responses">Responses</option>
-                  <option value="auto">Auto</option>
-                </select>
+              <button type="button" class="provider-card-toggle" @click="toggleProviderExpand(provider.id)">
+                <div class="provider-item-top">
+                  <strong>{{ provider.name }}</strong>
+                  <span :class="['provider-state', { active: provider.is_active }]">
+                    {{ provider.is_active ? 'Active' : 'Standby' }}
+                  </span>
+                </div>
+                <div class="provider-summary-grid">
+                  <p class="provider-model">
+                    {{ Array.isArray(provider.models) && provider.models.length > 0 ? provider.models[0] : '未配置 model' }}
+                  </p>
+                  <p class="provider-count">{{ providerModeLabel(provider.api_mode) }}</p>
+                  <p class="provider-count">{{ providerUsersCount(provider.id) }} 位用户</p>
+                </div>
+              </button>
+
+              <div class="provider-inline-actions">
                 <button
                   type="button"
-                  class="mini"
-                  :disabled="creatingProvider || savingByProvider[provider.id] || provider.is_active"
-                  @click.stop="activateProvider(provider)"
+                  class="ghost mini"
+                  @click="selectedSourceId = selectedSourceId === provider.id ? '' : provider.id"
                 >
-                  {{ provider.is_active ? 'Active' : '设为默认' }}
+                  {{ selectedSourceId === provider.id ? '取消筛选' : '筛选用户' }}
                 </button>
                 <button
                   type="button"
                   class="ghost mini"
                   :disabled="creatingProvider || savingByProvider[provider.id]"
-                  @click.stop="quickTestProvider(provider)"
+                  @click="quickTestProvider(provider)"
                 >
                   连通测试
                 </button>
+                <button
+                  type="button"
+                  class="mini"
+                  :disabled="creatingProvider || savingByProvider[provider.id] || provider.is_active"
+                  @click="activateProvider(provider)"
+                >
+                  {{ provider.is_active ? 'Active' : '设为默认' }}
+                </button>
               </div>
-              <div v-if="selectedSourceId === provider.id" class="provider-test-box" @click.stop>
-                <input
-                  :value="ensureProviderTestDraft(provider)"
-                  placeholder="输入一条测试消息，验证端点是否可用"
-                  @input="providerTestDrafts[provider.id] = $event.target.value"
-                />
-                <div class="provider-test-actions">
+
+              <div v-if="expandedProviderId === provider.id" class="provider-expander">
+                <label class="mini-form-field">
+                  <span>Name</span>
+                  <input v-model.trim="ensureProviderDraft(provider).name" placeholder="Provider 名称" />
+                </label>
+                <label class="mini-form-field">
+                  <span>Base URL</span>
+                  <input v-model.trim="ensureProviderDraft(provider).base_url" placeholder="https://api.example.com/v1" />
+                </label>
+                <label class="mini-form-field">
+                  <span>API Key</span>
+                  <input v-model.trim="ensureProviderDraft(provider).api_key" type="password" placeholder="sk-..." />
+                </label>
+                <div class="provider-expander-grid">
+                  <label class="mini-form-field">
+                    <span>API Mode</span>
+                    <select v-model="ensureProviderDraft(provider).api_mode">
+                      <option value="chat_completions">Chat Completions</option>
+                      <option value="responses">Responses</option>
+                      <option value="auto">Auto</option>
+                    </select>
+                  </label>
+                  <label class="mini-form-field">
+                    <span>Priority</span>
+                    <input v-model.trim="ensureProviderDraft(provider).priority" inputmode="numeric" placeholder="100" />
+                  </label>
+                </div>
+                <label class="mini-form-field">
+                  <span>Models（逗号分隔）</span>
+                  <input v-model.trim="ensureProviderDraft(provider).models" placeholder="gpt-4o-mini, gpt-4.1-mini" />
+                </label>
+
+                <div class="provider-item-actions">
+                  <button
+                    type="button"
+                    :disabled="savingByProvider[provider.id]"
+                    @click="saveProvider(provider)"
+                  >
+                    {{ savingByProvider[provider.id] ? '保存中...' : '保存配置' }}
+                  </button>
                   <button
                     type="button"
                     class="ghost mini"
                     :disabled="testingByProvider[provider.id]"
-                    @click.stop="runProviderMessageTest(provider)"
+                    @click="runProviderMessageTest(provider)"
                   >
                     {{ testingByProvider[provider.id] ? '测试中...' : '消息测试' }}
                   </button>
+                  <button
+                    type="button"
+                    class="ghost mini"
+                    :disabled="savingByProvider[provider.id] || provider.is_active"
+                    @click="removeProvider(provider)"
+                  >
+                    删除
+                  </button>
                 </div>
-                <p v-if="providerTestReplies[provider.id]" class="provider-test-reply">
-                  {{ providerTestReplies[provider.id] }}
-                </p>
+
+                <div class="provider-test-box">
+                  <input
+                    :value="ensureProviderTestDraft(provider)"
+                    placeholder="输入一条测试消息，验证端点是否可用"
+                    @input="providerTestDrafts[provider.id] = $event.target.value"
+                  />
+                  <p v-if="providerTestReplies[provider.id]" class="provider-test-reply">
+                    {{ providerTestReplies[provider.id] }}
+                  </p>
+                </div>
               </div>
             </article>
           </div>

--- a/Nukara_Admin_Web/src/style.css
+++ b/Nukara_Admin_Web/src/style.css
@@ -218,8 +218,7 @@ select {
   background: #f7f9f3;
   padding: 10px 12px;
   display: grid;
-  gap: 8px;
-  cursor: pointer;
+  gap: 10px;
 }
 
 .provider-item-card.selected {
@@ -227,11 +226,50 @@ select {
   background: rgba(123, 160, 91, 0.12);
 }
 
+.provider-item-card.expanded {
+  background: #fbfdf8;
+}
+
+.provider-card-toggle {
+  border: none;
+  background: transparent;
+  padding: 0;
+  width: 100%;
+  text-align: left;
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+}
+
 .provider-item-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 8px;
+}
+
+.provider-summary-grid {
+  display: grid;
+  gap: 4px;
+}
+
+.provider-inline-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.provider-expander {
+  display: grid;
+  gap: 10px;
+  padding-top: 6px;
+  border-top: 1px solid #e3e8d8;
+}
+
+.provider-expander-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .provider-state {
@@ -588,6 +626,15 @@ select {
   }
 
   .create-actions {
+    flex-direction: column;
+  }
+
+  .provider-expander-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-inline-actions,
+  .provider-item-actions {
     flex-direction: column;
   }
 }

--- a/Nukara_Backend/internal/admin/memory_graph_handler.go
+++ b/Nukara_Backend/internal/admin/memory_graph_handler.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -164,6 +165,75 @@ func buildMemoryGraphResponse(items []store.MemoryItem, ctx memoryGraphContext) 
 			MemoryCount:  len(items),
 			TopicCount:   len(topicSet),
 			GraphSource:  "store",
+			KindFilter:   strings.TrimSpace(ctx.KindFilter),
+			StatusFilter: strings.TrimSpace(ctx.StatusFilter),
+		},
+		RecentImpressions:     buildMemoryGraphMemoryItems(ctx.RecentImpressions),
+		RecentChanges:         buildMemoryGraphPersonaChanges(ctx.RecentChanges),
+		PendingPersonaChanges: buildMemoryGraphPersonaChanges(ctx.PendingPersonaChanges),
+	}
+	if ctx.RuntimeState != nil {
+		response.RuntimeState = &memoryGraphRuntimeState{
+			ActivityText:    strings.TrimSpace(ctx.RuntimeState.ActivityText),
+			BasisTags:       append([]string(nil), ctx.RuntimeState.BasisTags...),
+			SourceMemoryIDs: append([]string(nil), ctx.RuntimeState.SourceMemoryIDs...),
+			UpdatedAt:       ctx.RuntimeState.UpdatedAt,
+		}
+	}
+	return response
+}
+
+func buildTemporalMemoryGraphResponse(nodesInput []store.TemporalMemoryNode, edgesInput []store.TemporalMemoryEdge, ctx memoryGraphContext) memoryGraphResponse {
+	nodes := make([]memoryGraphNode, 0, len(nodesInput))
+	edges := make([]memoryGraphEdge, 0, len(edgesInput))
+	for _, node := range nodesInput {
+		label := strings.TrimSpace(node.Title)
+		if label == "" {
+			label = strings.TrimSpace(node.Summary)
+		}
+		if len([]rune(label)) > 24 {
+			runes := []rune(label)
+			label = string(runes[:24]) + "…"
+		}
+		importance := int(node.Salience * 100)
+		if importance <= 0 {
+			importance = int(node.Confidence * 100)
+		}
+		if importance <= 0 {
+			importance = int(node.Stability * 100)
+		}
+		nodes = append(nodes, memoryGraphNode{
+			ID:         strings.TrimSpace(node.ID),
+			Type:       "memory",
+			Label:      label,
+			Kind:       strings.TrimSpace(node.NodeType),
+			Status:     strings.TrimSpace(node.Status),
+			Content:    strings.TrimSpace(node.Summary),
+			Importance: importance,
+			OccurredAt: node.OccurredAt,
+		})
+	}
+	for _, edge := range edgesInput {
+		edges = append(edges, memoryGraphEdge{
+			ID:     strings.TrimSpace(edge.ID),
+			Source: strings.TrimSpace(edge.SourceID),
+			Target: strings.TrimSpace(edge.TargetID),
+			Type:   strings.TrimSpace(edge.EdgeType),
+		})
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].OccurredAt.Equal(nodes[j].OccurredAt) {
+			return nodes[i].ID < nodes[j].ID
+		}
+		return nodes[i].OccurredAt.After(nodes[j].OccurredAt)
+	})
+	response := memoryGraphResponse{
+		Nodes: nodes,
+		Edges: edges,
+		Summary: memoryGraphSummary{
+			MemoryCount:  len(nodes),
+			TopicCount:   0,
+			GraphSource:  "temporal_memory_graph",
 			KindFilter:   strings.TrimSpace(ctx.KindFilter),
 			StatusFilter: strings.TrimSpace(ctx.StatusFilter),
 		},
@@ -382,11 +452,7 @@ func (s *Server) handleAdminMemoryGraph(w http.ResponseWriter, r *http.Request, 
 		statusFilter = "active"
 	}
 
-	items, err := s.loadAdminMemoryItems(userID, botID, kindFilter, statusFilter, 200)
-	if err != nil {
-		http.Error(w, "Failed to load memory graph: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
+	temporalNodes, temporalEdges, temporalErr := s.loadAdminTemporalMemoryGraph(userID, botID, kindFilter, statusFilter, 200)
 	runtimeState, err := s.loadAdminRuntimeState(userID, botID)
 	if err != nil {
 		http.Error(w, "Failed to load runtime state: "+err.Error(), http.StatusInternalServerError)
@@ -408,15 +474,161 @@ func (s *Server) handleAdminMemoryGraph(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(buildMemoryGraphResponse(items, memoryGraphContext{
+	ctx := memoryGraphContext{
 		KindFilter:            kindFilter,
 		StatusFilter:          statusFilter,
 		RuntimeState:          runtimeState,
 		RecentImpressions:     recentImpressions,
 		RecentChanges:         recentChanges,
 		PendingPersonaChanges: pendingChanges,
-	}))
+	}
+	response := memoryGraphResponse{}
+	if temporalErr == nil && len(temporalNodes) > 0 {
+		response = buildTemporalMemoryGraphResponse(temporalNodes, temporalEdges, ctx)
+	} else {
+		items, fallbackErr := s.loadAdminMemoryItems(userID, botID, kindFilter, statusFilter, 200)
+		if fallbackErr != nil {
+			if temporalErr != nil {
+				http.Error(w, "Failed to load memory graph: "+temporalErr.Error()+"; fallback failed: "+fallbackErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			http.Error(w, "Failed to load memory graph: "+fallbackErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		response = buildMemoryGraphResponse(items, ctx)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func temporalNodeTypesForKind(kind string) []string {
+	switch strings.TrimSpace(kind) {
+	case "promise":
+		return []string{"promise"}
+	case "event":
+		return []string{"episode"}
+	case "self_fact":
+		return []string{"self_model", "state_snapshot"}
+	case "user_fact":
+		return []string{"user_fact"}
+	case "habit":
+		return []string{"habit"}
+	default:
+		return nil
+	}
+}
+
+func (s *Server) loadAdminTemporalMemoryGraph(userID, botID, kind, status string, limit int) ([]store.TemporalMemoryNode, []store.TemporalMemoryEdge, error) {
+	nodes, err := s.loadAdminTemporalMemoryNodes(userID, botID, kind, status, limit)
+	if err != nil || len(nodes) == 0 {
+		return nodes, nil, err
+	}
+	nodeIDs := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if id := strings.TrimSpace(node.ID); id != "" {
+			nodeIDs = append(nodeIDs, id)
+		}
+	}
+	edges, err := s.loadAdminTemporalMemoryEdges(nodeIDs, status, limit*3)
+	return nodes, edges, err
+}
+
+func (s *Server) loadAdminTemporalMemoryNodes(userID, botID, kind, status string, limit int) ([]store.TemporalMemoryNode, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	query := `
+		SELECT id::text, user_id::text, bot_id::text, COALESCE(session_id::text, ''), node_type, title, summary, body_json,
+			salience, affect_weight, confidence, stability, status, occurred_at, observed_at,
+			valid_from, valid_to, last_accessed_at, COALESCE(source_turn_id::text, ''), created_at, updated_at
+		FROM memory_nodes
+		WHERE user_id = $1 AND bot_id = $2`
+	args := []any{strings.TrimSpace(userID), strings.TrimSpace(botID)}
+	if status = strings.TrimSpace(status); status != "" {
+		query += fmt.Sprintf(" AND status = $%d", len(args)+1)
+		args = append(args, status)
+	}
+	nodeTypes := temporalNodeTypesForKind(kind)
+	if len(nodeTypes) > 0 {
+		placeholders := make([]string, 0, len(nodeTypes))
+		for _, nodeType := range nodeTypes {
+			args = append(args, nodeType)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		query += " AND node_type IN (" + strings.Join(placeholders, ", ") + ")"
+	}
+	query += fmt.Sprintf(" ORDER BY occurred_at DESC, updated_at DESC LIMIT $%d", len(args)+1)
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]store.TemporalMemoryNode, 0, limit)
+	for rows.Next() {
+		var item store.TemporalMemoryNode
+		var bodyRaw []byte
+		var validTo sql.NullTime
+		if err := rows.Scan(&item.ID, &item.UserID, &item.BotID, &item.SessionID, &item.NodeType, &item.Title, &item.Summary, &bodyRaw, &item.Salience, &item.AffectWeight, &item.Confidence, &item.Stability, &item.Status, &item.OccurredAt, &item.ObservedAt, &item.ValidFrom, &validTo, &item.LastAccessedAt, &item.SourceTurnID, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, err
+		}
+		item.BodyJSON = strings.TrimSpace(string(bodyRaw))
+		if validTo.Valid {
+			value := validTo.Time.UTC()
+			item.ValidTo = &value
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func (s *Server) loadAdminTemporalMemoryEdges(nodeIDs []string, status string, limit int) ([]store.TemporalMemoryEdge, error) {
+	if len(nodeIDs) == 0 {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 600
+	}
+	args := make([]any, 0, len(nodeIDs)*2+2)
+	placeholdersLeft := make([]string, 0, len(nodeIDs))
+	placeholdersRight := make([]string, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		args = append(args, nodeID)
+		placeholdersLeft = append(placeholdersLeft, fmt.Sprintf("$%d", len(args)))
+	}
+	for _, nodeID := range nodeIDs {
+		args = append(args, nodeID)
+		placeholdersRight = append(placeholdersRight, fmt.Sprintf("$%d", len(args)))
+	}
+	query := `
+		SELECT id::text, source_id::text, target_id::text, edge_type, weight, evidence_count, status, created_at, updated_at
+		FROM memory_edges
+		WHERE (source_id::text IN (` + strings.Join(placeholdersLeft, ", ") + `) OR target_id::text IN (` + strings.Join(placeholdersRight, ", ") + `))`
+	if status = strings.TrimSpace(status); status != "" {
+		args = append(args, status)
+		query += fmt.Sprintf(" AND status = $%d", len(args))
+	}
+	args = append(args, limit)
+	query += fmt.Sprintf(" ORDER BY updated_at DESC LIMIT $%d", len(args))
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]store.TemporalMemoryEdge, 0, limit)
+	for rows.Next() {
+		var item store.TemporalMemoryEdge
+		if err := rows.Scan(&item.ID, &item.SourceID, &item.TargetID, &item.EdgeType, &item.Weight, &item.EvidenceCount, &item.Status, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, nil
 }
 
 func (s *Server) loadAdminRecentImpressions(userID, botID string, limit int) ([]store.MemoryItem, error) {

--- a/Nukara_Backend/internal/admin/memory_graph_handler_test.go
+++ b/Nukara_Backend/internal/admin/memory_graph_handler_test.go
@@ -33,6 +33,51 @@ func TestBuildMemoryGraphResponseCreatesMemoryTopicNodesAndEdges(t *testing.T) {
 	}
 }
 
+func TestBuildTemporalMemoryGraphResponseIncludesTemporalNodesAndEdges(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	graph := buildTemporalMemoryGraphResponse([]store.TemporalMemoryNode{
+		{
+			ID:         "tm:turn-1:promise:m1",
+			NodeType:   "promise",
+			Title:      "摄影课",
+			Summary:    "这周要把摄影课报上",
+			Status:     "active",
+			OccurredAt: now.Add(-time.Hour),
+			Salience:   0.86,
+		},
+		{
+			ID:         "session-summary:conv-1",
+			NodeType:   "session_summary",
+			Title:      "会话摘要",
+			Summary:    "最近一直在聊散步和摄影课",
+			Status:     "active",
+			OccurredAt: now,
+			Salience:   0.91,
+		},
+	}, []store.TemporalMemoryEdge{{
+		ID:       "edge-1",
+		SourceID: "tm:turn-1:promise:m1",
+		TargetID: "session-summary:conv-1",
+		EdgeType: "summarizes",
+	}}, memoryGraphContext{})
+
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("expected 2 graph nodes, got %d", len(graph.Nodes))
+	}
+	if len(graph.Edges) != 1 {
+		t.Fatalf("expected 1 graph edge, got %d", len(graph.Edges))
+	}
+	if graph.Summary.MemoryCount != 2 {
+		t.Fatalf("memory_count = %d, want 2", graph.Summary.MemoryCount)
+	}
+	if graph.Summary.GraphSource != "temporal_memory_graph" {
+		t.Fatalf("graph_source = %q, want temporal_memory_graph", graph.Summary.GraphSource)
+	}
+	if graph.Nodes[0].Type != "memory" && graph.Nodes[1].Type != "memory" {
+		t.Fatalf("expected temporal nodes to map to memory nodes: %+v", graph.Nodes)
+	}
+}
+
 func TestBuildMemoryGraphResponseIncludesRuntimeProfileViews(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	graph := buildMemoryGraphResponse([]store.MemoryItem{

--- a/Nukara_Backend/internal/agentx/runtime.go
+++ b/Nukara_Backend/internal/agentx/runtime.go
@@ -54,8 +54,12 @@ func (r *Runtime) StreamTurn(ctx context.Context, req TurnRequest) (<-chan Strea
 	client := r.providerClient
 	providerMode := "default"
 	providerBaseURL := ""
+	providerConversationID := strings.TrimSpace(req.ProviderConversationID)
+	if providerConversationID == "" {
+		providerConversationID = strings.TrimSpace(req.ConversationID)
+	}
 	request := llm.ChatRequest{
-		ConversationID: req.ConversationID,
+		ConversationID: providerConversationID,
 		RobotID:        req.BotID,
 		Prompt:         req.AggregatedText,
 		SystemContext:  req.SystemContext,

--- a/Nukara_Backend/internal/agentx/types.go
+++ b/Nukara_Backend/internal/agentx/types.go
@@ -3,15 +3,16 @@ package agentx
 import "nukara/backend/internal/agentx/llm"
 
 type TurnRequest struct {
-	UserID         string
-	BotID          string
-	ConversationID string
-	AggregatedText string
-	UserMessageIDs []string
-	SystemContext  map[string]any
-	SystemPrompt   string
-	Purpose        string
-	History        []llm.ChatMessage
+	UserID                 string
+	BotID                  string
+	ConversationID         string
+	ProviderConversationID string
+	AggregatedText         string
+	UserMessageIDs         []string
+	SystemContext          map[string]any
+	SystemPrompt           string
+	Purpose                string
+	History                []llm.ChatMessage
 }
 
 type StreamDelta struct {

--- a/Nukara_Backend/internal/api/bot_profile.go
+++ b/Nukara_Backend/internal/api/bot_profile.go
@@ -137,8 +137,8 @@ func (s *Server) handleBotImpression(w http.ResponseWriter, r *http.Request, use
 2) 80字以内，语气自然。
 3) 包含对方沟通风格/兴趣或情绪倾向中的1-2点。`
 
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
-	raw, _, _, _, err := s.runRuntimeChatText(context.Background(), userID, bot.ID, convID, prompt, sysCtx)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	raw, _, _, _, err := s.runRuntimeChatTextWithProviderConversation(context.Background(), userID, bot.ID, conv.ID, providerConversationID, prompt, sysCtx)
 	if err != nil {
 		respondJSON(w, http.StatusBadGateway, map[string]any{"error": "impression generation failed"})
 		return
@@ -211,8 +211,8 @@ func (s *Server) handleBotIterate(w http.ResponseWriter, r *http.Request, userID
 	sysCtx := agent.BuildSystemContext(bot, directives)
 	prompt := buildIteratePrompt(messages)
 
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
-	raw, _, _, _, err := s.runRuntimeChatText(context.Background(), userID, bot.ID, convID, prompt, sysCtx)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	raw, _, _, _, err := s.runRuntimeChatTextWithProviderConversation(context.Background(), userID, bot.ID, conv.ID, providerConversationID, prompt, sysCtx)
 	if err != nil {
 		respondJSON(w, http.StatusBadGateway, map[string]any{"error": "iterate generation failed"})
 		return

--- a/Nukara_Backend/internal/api/chat_flow.go
+++ b/Nukara_Backend/internal/api/chat_flow.go
@@ -76,14 +76,14 @@ func (s *Server) processChatMessage(userID string, req chatMessageRequest) (chat
 	}
 	s.store.SetLastUserMessageAt(userID, userMessage.CreatedAt)
 
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, conv.ID)
 	var userStatusStr string
 	if us, ok := s.store.GetUserStatus(userID); ok && (us.Emoji != "" || us.Text != "") {
 		userStatusStr = us.Emoji + " " + us.Text
 	}
 	directives := s.store.ListDirectives(userID, bot.ID, "active")
 	sysCtx := agent.BuildSystemContext(bot, directives, userStatusStr)
-	reply, emotion, statusEmoji, statusText, err := s.runRuntimeChatText(context.Background(), userID, bot.ID, convID, prompt, sysCtx)
+	reply, emotion, statusEmoji, statusText, err := s.runRuntimeChatTextWithProviderConversation(context.Background(), userID, bot.ID, conv.ID, providerConversationID, prompt, sysCtx)
 	if err != nil {
 		log.Printf("[chat_flow] runtime chat failed: %v", err)
 		reply = fmt.Sprintf("%s：我记住了你说的。要不要继续聊聊？", bot.Name)
@@ -226,13 +226,14 @@ func selectBotStatus(emotion, conversationID string) botStatusValue {
 }
 
 func (s *Server) generateStarterMessage(userID string, bot store.Bot, convID string) string {
-	nbConvID := agent.NanobotConvID(userID, bot.ID, convID)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, convID)
 	sysCtx := agent.BuildSystemContext(bot, nil)
-	reply, _, _, _, err := s.runRuntimeChatText(
+	reply, _, _, _, err := s.runRuntimeChatTextWithProviderConversation(
 		context.Background(),
 		userID,
 		bot.ID,
-		nbConvID,
+		convID,
+		providerConversationID,
 		"现在直接向用户说一句简短的开场问候。直接输出你要说的话，不要使用工具，不要解释，只输出对话内容。",
 		sysCtx,
 	)

--- a/Nukara_Backend/internal/api/email_auth_test.go
+++ b/Nukara_Backend/internal/api/email_auth_test.go
@@ -2,14 +2,25 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"nukara/backend/internal/apns"
 	"nukara/backend/internal/store"
 )
+
+type countingEmailSender struct {
+	calls int
+}
+
+func (s *countingEmailSender) SendVerificationCode(_ context.Context, _ string, _ string, _ time.Duration) error {
+	s.calls++
+	return nil
+}
 
 func TestEmailAuthSendRequiresSMTPConfig(t *testing.T) {
 	st := store.NewStore()
@@ -72,6 +83,32 @@ func TestEmailAuthLoginUsesEmailCode(t *testing.T) {
 	srv.HandlerFor("account").ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestEmailAuthSendSuppressesImmediateDuplicateEmails(t *testing.T) {
+	st := store.NewStore()
+	srv := NewServer(st, nil, apns.NewClient("com.nukara.app"), "test-secret", "")
+	sender := &countingEmailSender{}
+	srv.emailSender = sender
+
+	body := bytes.NewBufferString(`{"email":"tester@example.com","purpose":"register"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/send", body)
+	rec := httptest.NewRecorder()
+	srv.HandlerFor("account").ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	body2 := bytes.NewBufferString(`{"email":"tester@example.com","purpose":"register"}`)
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/send", body2)
+	rec2 := httptest.NewRecorder()
+	srv.HandlerFor("account").ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want %d, body=%s", rec2.Code, http.StatusOK, rec2.Body.String())
+	}
+	if sender.calls != 1 {
+		t.Fatalf("email sender calls = %d, want 1", sender.calls)
 	}
 }
 

--- a/Nukara_Backend/internal/api/emotion_tracker.go
+++ b/Nukara_Backend/internal/api/emotion_tracker.go
@@ -50,9 +50,9 @@ func (s *Server) runEmotionAnalysis(userID string, bot store.Bot, conv store.Con
 	defer cancel()
 
 	prompt := buildEmotionPrompt(messages)
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, conv.ID)
 	sysCtx := agent.BuildSystemContext(bot, nil)
-	reply, _, _, _, err := s.runRuntimeChatText(ctx, userID, bot.ID, convID, prompt, sysCtx)
+	reply, _, _, _, err := s.runRuntimeChatTextWithProviderConversation(ctx, userID, bot.ID, conv.ID, providerConversationID, prompt, sysCtx)
 	if err != nil {
 		log.Printf("[emotion] runtime analysis failed: user=%s bot=%s err=%v", userID, bot.ID, err)
 		return

--- a/Nukara_Backend/internal/api/runtime_adapter.go
+++ b/Nukara_Backend/internal/api/runtime_adapter.go
@@ -53,9 +53,13 @@ func (s *Server) runRuntimeChat(ctx context.Context, req agentx.TurnRequest) (te
 }
 
 func (s *Server) runRuntimeChatText(ctx context.Context, userID, botID, conversationID, prompt string, systemContext map[string]any) (string, string, string, string, error) {
+	return s.runRuntimeChatTextWithProviderConversation(ctx, userID, botID, conversationID, conversationID, prompt, systemContext)
+}
+
+func (s *Server) runRuntimeChatTextWithProviderConversation(ctx context.Context, userID, botID, conversationID, providerConversationID, prompt string, systemContext map[string]any) (string, string, string, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
-	return s.runRuntimeChat(ctx, s.newTurnRequest(userID, botID, conversationID, prompt, nil, systemContext))
+	return s.runRuntimeChat(ctx, s.newTurnRequestWithProviderConversation(userID, botID, conversationID, providerConversationID, prompt, nil, systemContext))
 }
 
 func (s *Server) runRuntimeProactive(ctx context.Context, userID, botID, conversationID, trigger string, systemContext map[string]any) (string, string, string, string, error) {

--- a/Nukara_Backend/internal/api/runtime_context.go
+++ b/Nukara_Backend/internal/api/runtime_context.go
@@ -21,17 +21,27 @@ const (
 )
 
 func (s *Server) newTurnRequest(userID, botID, conversationID, prompt string, userMessageIDs []string, systemContext map[string]any) agentx.TurnRequest {
+	return s.newTurnRequestWithProviderConversation(userID, botID, conversationID, conversationID, prompt, userMessageIDs, systemContext)
+}
+
+func (s *Server) newTurnRequestWithProviderConversation(userID, botID, conversationID, providerConversationID, prompt string, userMessageIDs []string, systemContext map[string]any) agentx.TurnRequest {
 	enrichedContext := enrichLocaleSystemContext(systemContext, time.Now().UTC())
-	systemPrompt, history := s.buildRuntimeContext(userID, botID, conversationID, prompt, userMessageIDs, enrichedContext)
+	localConversationID := strings.TrimSpace(conversationID)
+	systemPrompt, history := s.buildRuntimeContext(userID, botID, localConversationID, prompt, userMessageIDs, enrichedContext)
+	providerConversationID = strings.TrimSpace(providerConversationID)
+	if providerConversationID == "" {
+		providerConversationID = localConversationID
+	}
 	return agentx.TurnRequest{
-		UserID:         strings.TrimSpace(userID),
-		BotID:          strings.TrimSpace(botID),
-		ConversationID: strings.TrimSpace(conversationID),
-		AggregatedText: strings.TrimSpace(prompt),
-		UserMessageIDs: append([]string(nil), userMessageIDs...),
-		SystemContext:  enrichedContext,
-		SystemPrompt:   systemPrompt,
-		History:        history,
+		UserID:                 strings.TrimSpace(userID),
+		BotID:                  strings.TrimSpace(botID),
+		ConversationID:         localConversationID,
+		ProviderConversationID: providerConversationID,
+		AggregatedText:         strings.TrimSpace(prompt),
+		UserMessageIDs:         append([]string(nil), userMessageIDs...),
+		SystemContext:          enrichedContext,
+		SystemPrompt:           systemPrompt,
+		History:                history,
 	}
 }
 

--- a/Nukara_Backend/internal/api/runtime_context_test.go
+++ b/Nukara_Backend/internal/api/runtime_context_test.go
@@ -74,3 +74,41 @@ func TestRuntimeContextIncludesRuntimeStateAndPromises(t *testing.T) {
 		t.Fatalf("expected promise block in prompt, got=%s", prompt)
 	}
 }
+
+func TestNewTurnRequestSeparatesProviderConversationIDFromLocalConversationID(t *testing.T) {
+	st := store.NewStore()
+	user, err := st.CreateUser("13900139004", "runtime-conversation-id")
+	if err != nil {
+		t.Fatalf("create user failed: %v", err)
+	}
+	bot := st.CreateBot(user.ID, store.Bot{Name: "苏子衿", Identity: "温柔的人"})
+	conv, found := st.FindConversationByBot(user.ID, bot.ID)
+	if !found {
+		t.Fatalf("conversation not found")
+	}
+	if err := st.UpsertCompact(conv.ID, `{"summary":"这是一段本地会话摘要"}`, "turn-1"); err != nil {
+		t.Fatalf("upsert compact failed: %v", err)
+	}
+
+	server := NewServer(st, nil, apns.NewClient("com.nukara.app"), "test-secret", "")
+	providerConversationID := agent.NanobotConvID(user.ID, bot.ID, conv.ID)
+	request := server.newTurnRequestWithProviderConversation(
+		user.ID,
+		bot.ID,
+		conv.ID,
+		providerConversationID,
+		"你还记得我们刚才聊什么吗",
+		nil,
+		agent.BuildSystemContext(bot, nil),
+	)
+
+	if request.ConversationID != conv.ID {
+		t.Fatalf("local conversation id = %q, want %q", request.ConversationID, conv.ID)
+	}
+	if request.ProviderConversationID != providerConversationID {
+		t.Fatalf("provider conversation id = %q, want %q", request.ProviderConversationID, providerConversationID)
+	}
+	if !strings.Contains(request.SystemPrompt, "这是一段本地会话摘要") {
+		t.Fatalf("expected compact from local conversation id, got=%s", request.SystemPrompt)
+	}
+}

--- a/Nukara_Backend/internal/api/scheduler.go
+++ b/Nukara_Backend/internal/api/scheduler.go
@@ -305,7 +305,7 @@ func shouldBlockTriggerForPresence(trigger string, online bool, lastUserAt, now 
 // sendProactiveMessage generates and delivers a proactive message for a user+bot pair.
 // Reused by both the scheduler and the manual trigger API.
 func (s *Server) sendProactiveMessage(userID string, bot store.Bot, conv store.Conversation, triggerType string) {
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	localConversationID := conv.ID
 	sysCtx := agent.BuildSystemContext(bot, nil)
 	now := time.Now().UTC()
 
@@ -322,7 +322,7 @@ func (s *Server) sendProactiveMessage(userID string, bot store.Bot, conv store.C
 		sysCtx["last_user_message"] = lastText
 	}
 
-	message, emotion, _, _, err := s.runRuntimeProactive(context.Background(), userID, bot.ID, convID, triggerType, sysCtx)
+	message, emotion, _, _, err := s.runRuntimeProactive(context.Background(), userID, bot.ID, localConversationID, triggerType, sysCtx)
 	if err != nil {
 		log.Printf("[scheduler] runtime proactive failed: %v", err)
 		message = fmt.Sprintf("%s：刚想到你了，最近怎么样？", bot.Name)

--- a/Nukara_Backend/internal/api/server.go
+++ b/Nukara_Backend/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	stdmail "net/mail"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"nukara/backend/internal/agent"
@@ -26,6 +27,8 @@ import (
 	internalmail "nukara/backend/internal/mail"
 	"nukara/backend/internal/store"
 )
+
+const defaultEmailSendCooldown = 60 * time.Second
 
 type wsChatRuntime interface {
 	StreamTurn(ctx context.Context, req agentx.TurnRequest) (<-chan agentx.StreamDelta, <-chan agentx.FinalTurn, error)
@@ -60,11 +63,13 @@ type Server struct {
 	subtasks       interface {
 		Run(ctx context.Context, in subtasks.Input) (subtasks.Result, error)
 	}
-	apns        *apns.Client
-	wsHub       *wsHub
-	emailSender verificationEmailSender
-	tokenKey    []byte
-	tokenTTL    time.Duration
+	apns              *apns.Client
+	wsHub             *wsHub
+	emailSender       verificationEmailSender
+	emailSendMu       sync.Mutex
+	emailSendCooldown time.Duration
+	tokenKey          []byte
+	tokenTTL          time.Duration
 }
 
 func NewServer(st store.DataStore, agentClient *agent.Agent, apnsClient *apns.Client, tokenSecret string, redisAddr string) *Server {
@@ -72,14 +77,15 @@ func NewServer(st store.DataStore, agentClient *agent.Agent, apnsClient *apns.Cl
 		tokenSecret = "nukara-dev-secret"
 	}
 	s := &Server{
-		store:          st,
-		agent:          agentClient,
-		apns:           apnsClient,
-		wsHub:          newWSHub(st, redisAddr),
-		emailSender:    internalmail.NewSMTPSender(st),
-		tokenKey:       []byte(tokenSecret),
-		tokenTTL:       30 * 24 * time.Hour,
-		temporalRecall: memorygraph.NewService(memorygraph.ServiceDeps{Store: st}),
+		store:             st,
+		agent:             agentClient,
+		apns:              apnsClient,
+		wsHub:             newWSHub(st, redisAddr),
+		emailSender:       internalmail.NewSMTPSender(st),
+		emailSendCooldown: defaultEmailSendCooldown,
+		tokenKey:          []byte(tokenSecret),
+		tokenTTL:          30 * 24 * time.Hour,
+		temporalRecall:    memorygraph.NewService(memorygraph.ServiceDeps{Store: st}),
 	}
 	if agentClient != nil {
 		deps := agentx.RuntimeDeps{
@@ -198,7 +204,6 @@ func (s *Server) handleEmailSend(w http.ResponseWriter, r *http.Request) {
 		badRequest(w, errors.New("invalid email or purpose"))
 		return
 	}
-	code := fmt.Sprintf("%06d", rand.Intn(1000000))
 	if s.emailSender == nil {
 		badRequest(w, errors.New("smtp not configured"))
 		return
@@ -207,6 +212,18 @@ func (s *Server) handleEmailSend(w http.ResponseWriter, r *http.Request) {
 	if cfg, err := internalmail.LoadSMTPConfig(s.store); err == nil && cfg.CodeTTL > 0 {
 		ttl = cfg.CodeTTL
 	}
+
+	s.emailSendMu.Lock()
+	defer s.emailSendMu.Unlock()
+	if existing, ok := s.store.GetLatestEmailCode(email, req.Purpose); ok {
+		now := time.Now().UTC()
+		if !existing.ExpiresAt.IsZero() && existing.ExpiresAt.After(now) && !existing.CreatedAt.IsZero() && now.Sub(existing.CreatedAt.UTC()) < s.emailSendCooldown {
+			respondJSON(w, http.StatusOK, map[string]any{"success": true, "message": "验证码已发送到邮箱"})
+			return
+		}
+	}
+
+	code := fmt.Sprintf("%06d", rand.Intn(1000000))
 	if err := s.emailSender.SendVerificationCode(r.Context(), email, code, ttl); err != nil {
 		status := http.StatusBadRequest
 		if !strings.Contains(strings.ToLower(err.Error()), "smtp not configured") && !strings.Contains(strings.ToLower(err.Error()), "invalid smtp") {
@@ -926,9 +943,9 @@ func (s *Server) handleGatewayTestChat(w http.ResponseWriter, r *http.Request) {
 		Content:        store.MessageContent{Type: "text", Text: strings.TrimSpace(req.Message)},
 	})
 
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, conv.ID)
 	sysCtx := agent.BuildSystemContext(bot, nil)
-	reply, emotion, _, _, chatErr := s.runRuntimeChatText(context.Background(), userID, bot.ID, convID, req.Message, sysCtx)
+	reply, emotion, _, _, chatErr := s.runRuntimeChatTextWithProviderConversation(context.Background(), userID, bot.ID, conv.ID, providerConversationID, req.Message, sysCtx)
 	if chatErr != nil {
 		log.Printf("[server] runtime chat failed: %v", chatErr)
 		reply = fmt.Sprintf("%s：我记住了你说的。要不要继续聊聊？", bot.Name)
@@ -991,9 +1008,9 @@ func (s *Server) handleGatewayTestChatStream(w http.ResponseWriter, r *http.Requ
 		Content:        store.MessageContent{Type: "text", Text: strings.TrimSpace(req.Message)},
 	})
 
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	providerConversationID := agent.NanobotConvID(userID, bot.ID, conv.ID)
 	sysCtx := agent.BuildSystemContext(bot, nil)
-	reply, emotion, _, _, chatErr := s.runRuntimeChatText(context.Background(), userID, bot.ID, convID, req.Message, sysCtx)
+	reply, emotion, _, _, chatErr := s.runRuntimeChatTextWithProviderConversation(context.Background(), userID, bot.ID, conv.ID, providerConversationID, req.Message, sysCtx)
 	if chatErr != nil {
 		log.Printf("[server] runtime chat(stream) failed: %v", chatErr)
 		reply = fmt.Sprintf("%s：我记住了你说的。要不要继续聊聊？", bot.Name)
@@ -1082,9 +1099,9 @@ func (s *Server) handleGatewayTestProactive(w http.ResponseWriter, r *http.Reque
 		req.TriggerType = "manual"
 	}
 
-	convID := agent.NanobotConvID(userID, bot.ID, conv.ID)
+	localConversationID := conv.ID
 	sysCtx := agent.BuildSystemContext(bot, nil)
-	message, _, _, _, proactiveErr := s.runRuntimeProactive(context.Background(), userID, bot.ID, convID, req.TriggerType, sysCtx)
+	message, _, _, _, proactiveErr := s.runRuntimeProactive(context.Background(), userID, bot.ID, localConversationID, req.TriggerType, sysCtx)
 	if proactiveErr != nil {
 		log.Printf("[server] runtime proactive failed: %v", proactiveErr)
 		message = fmt.Sprintf("%s：刚想到你了，最近怎么样？", bot.Name)

--- a/Nukara_Backend/internal/store/interface.go
+++ b/Nukara_Backend/internal/store/interface.go
@@ -14,6 +14,7 @@ type DataStore interface {
 	GetLastUserMessageAt(userID string) (time.Time, bool)
 
 	SaveEmailCode(email, purpose, code string, ttl time.Duration)
+	GetLatestEmailCode(email, purpose string) (EmailCode, bool)
 	ValidateEmailCode(email, purpose, code string) bool
 	FindUserByEmail(email string) (User, bool)
 	FindUserByID(id string) (User, bool)

--- a/Nukara_Backend/internal/store/postgres_store.go
+++ b/Nukara_Backend/internal/store/postgres_store.go
@@ -405,11 +405,19 @@ CREATE TABLE IF NOT EXISTS agent_turns (
 );
 
 CREATE TABLE IF NOT EXISTS conversation_compacts (
-    conversation_id UUID PRIMARY KEY,
+    conversation_id TEXT PRIMARY KEY,
     compact_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-    until_turn_id UUID,
+    until_turn_id TEXT,
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+DO $$ BEGIN
+    BEGIN
+        ALTER TABLE IF EXISTS conversation_compacts ALTER COLUMN conversation_id TYPE TEXT USING conversation_id::text;
+        ALTER TABLE IF EXISTS conversation_compacts ALTER COLUMN until_turn_id TYPE TEXT USING until_turn_id::text;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
+END $$;
 
 CREATE TABLE IF NOT EXISTS memory_items (
     id UUID PRIMARY KEY,
@@ -444,13 +452,20 @@ CREATE TABLE IF NOT EXISTS persona_change_events (
     field VARCHAR(40) NOT NULL,
     change_type VARCHAR(20) NOT NULL DEFAULT 'append',
     proposed_value TEXT NOT NULL,
-    source_turn_id UUID,
+    source_turn_id TEXT,
     risk VARCHAR(20) NOT NULL DEFAULT 'low',
     status VARCHAR(20) NOT NULL DEFAULT 'pending',
     reviewer_note TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+DO $$ BEGIN
+    BEGIN
+        ALTER TABLE IF EXISTS persona_change_events ALTER COLUMN source_turn_id TYPE TEXT USING source_turn_id::text;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_persona_change_events_user_bot ON persona_change_events(user_id, bot_id, status, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS agent_traces (
@@ -626,6 +641,29 @@ func (p *PostgresStore) SaveEmailCode(email, purpose, code string, ttl time.Dura
 	if err != nil {
 		log.Printf("save email code to postgres failed: %v", err)
 	}
+}
+
+func (p *PostgresStore) GetLatestEmailCode(email, purpose string) (EmailCode, bool) {
+	ctx, cancel := p.withTimeout()
+	defer cancel()
+
+	var entry EmailCode
+	err := p.db.QueryRowContext(ctx,
+		`SELECT email, purpose, code, created_at, expires_at
+		 FROM email_codes
+		 WHERE email=$1 AND purpose=$2 AND used=FALSE
+		 ORDER BY created_at DESC
+		 LIMIT 1`,
+		email, purpose,
+	).Scan(&entry.Email, &entry.Purpose, &entry.Code, &entry.CreatedAt, &entry.ExpiresAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return p.Store.GetLatestEmailCode(email, purpose)
+		}
+		log.Printf("get latest email code query failed: %v", err)
+		return p.Store.GetLatestEmailCode(email, purpose)
+	}
+	return entry, true
 }
 
 func (p *PostgresStore) ValidateEmailCode(email, purpose, code string) bool {

--- a/Nukara_Backend/internal/store/postgres_temporal_memory_graph.go
+++ b/Nukara_Backend/internal/store/postgres_temporal_memory_graph.go
@@ -21,10 +21,10 @@ BEGIN
 END $$;
 
 CREATE TABLE IF NOT EXISTS memory_nodes (
-    id UUID PRIMARY KEY,
+    id TEXT PRIMARY KEY,
     user_id UUID NOT NULL,
     bot_id UUID NOT NULL,
-    session_id UUID,
+    session_id TEXT,
     node_type VARCHAR(40) NOT NULL,
     title TEXT NOT NULL DEFAULT '',
     summary TEXT NOT NULL DEFAULT '',
@@ -39,18 +39,31 @@ CREATE TABLE IF NOT EXISTS memory_nodes (
     valid_from TIMESTAMP NOT NULL DEFAULT NOW(),
     valid_to TIMESTAMP,
     last_accessed_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    source_turn_id UUID,
+    source_turn_id TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE IF EXISTS memory_embeddings DROP CONSTRAINT IF EXISTS memory_embeddings_node_id_fkey;
+        ALTER TABLE IF EXISTS memory_edges DROP CONSTRAINT IF EXISTS memory_edges_source_id_fkey;
+        ALTER TABLE IF EXISTS memory_edges DROP CONSTRAINT IF EXISTS memory_edges_target_id_fkey;
+        ALTER TABLE IF EXISTS memory_nodes ALTER COLUMN id TYPE TEXT USING id::text;
+        ALTER TABLE IF EXISTS memory_nodes ALTER COLUMN session_id TYPE TEXT USING session_id::text;
+        ALTER TABLE IF EXISTS memory_nodes ALTER COLUMN source_turn_id TYPE TEXT USING source_turn_id::text;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_memory_nodes_user_bot ON memory_nodes(user_id, bot_id, status, occurred_at DESC);
 CREATE INDEX IF NOT EXISTS idx_memory_nodes_type ON memory_nodes(user_id, bot_id, node_type, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_memory_nodes_session ON memory_nodes(user_id, bot_id, session_id, updated_at DESC);
 
 CREATE TABLE IF NOT EXISTS memory_edges (
     id UUID PRIMARY KEY,
-    source_id UUID NOT NULL REFERENCES memory_nodes(id) ON DELETE CASCADE,
-    target_id UUID NOT NULL REFERENCES memory_nodes(id) ON DELETE CASCADE,
+    source_id TEXT NOT NULL REFERENCES memory_nodes(id) ON DELETE CASCADE,
+    target_id TEXT NOT NULL REFERENCES memory_nodes(id) ON DELETE CASCADE,
     edge_type VARCHAR(40) NOT NULL,
     weight DOUBLE PRECISION NOT NULL DEFAULT 1,
     evidence_count INT NOT NULL DEFAULT 1,
@@ -58,12 +71,31 @@ CREATE TABLE IF NOT EXISTS memory_edges (
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE IF EXISTS memory_edges ALTER COLUMN source_id TYPE TEXT USING source_id::text;
+        ALTER TABLE IF EXISTS memory_edges ALTER COLUMN target_id TYPE TEXT USING target_id::text;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
+    BEGIN
+        ALTER TABLE memory_edges ADD CONSTRAINT memory_edges_source_id_fkey FOREIGN KEY (source_id) REFERENCES memory_nodes(id) ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN
+        NULL;
+    END;
+    BEGIN
+        ALTER TABLE memory_edges ADD CONSTRAINT memory_edges_target_id_fkey FOREIGN KEY (target_id) REFERENCES memory_nodes(id) ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN
+        NULL;
+    END;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_memory_edges_source ON memory_edges(source_id, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_memory_edges_target ON memory_edges(target_id, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_memory_edges_type ON memory_edges(edge_type, updated_at DESC);
 
 CREATE TABLE IF NOT EXISTS memory_embeddings (
-    node_id UUID PRIMARY KEY REFERENCES memory_nodes(id) ON DELETE CASCADE,
+    node_id TEXT PRIMARY KEY REFERENCES memory_nodes(id) ON DELETE CASCADE,
     embedding_model TEXT NOT NULL DEFAULT '',
     embedding_json JSONB NOT NULL DEFAULT '[]'::jsonb,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -71,6 +103,16 @@ CREATE TABLE IF NOT EXISTS memory_embeddings (
 );
 DO $$
 BEGIN
+    BEGIN
+        ALTER TABLE IF EXISTS memory_embeddings ALTER COLUMN node_id TYPE TEXT USING node_id::text;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
+    BEGIN
+        ALTER TABLE memory_embeddings ADD CONSTRAINT memory_embeddings_node_id_fkey FOREIGN KEY (node_id) REFERENCES memory_nodes(id) ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN
+        NULL;
+    END;
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
         BEGIN
             ALTER TABLE memory_embeddings ADD COLUMN IF NOT EXISTS embedding vector(1536);
@@ -98,8 +140,8 @@ CREATE TABLE IF NOT EXISTS activation_traces (
     id UUID PRIMARY KEY,
     user_id UUID NOT NULL,
     bot_id UUID NOT NULL,
-    conversation_id UUID,
-    turn_id UUID,
+    conversation_id TEXT,
+    turn_id TEXT,
     cue_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     seed_node_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
     activated_node_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
@@ -107,6 +149,15 @@ CREATE TABLE IF NOT EXISTS activation_traces (
     response_excerpt TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE IF EXISTS activation_traces ALTER COLUMN conversation_id TYPE TEXT USING conversation_id::text;
+        ALTER TABLE IF EXISTS activation_traces ALTER COLUMN turn_id TYPE TEXT USING turn_id::text;
+    EXCEPTION WHEN OTHERS THEN
+        NULL;
+    END;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_activation_traces_user_bot ON activation_traces(user_id, bot_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_activation_traces_conversation ON activation_traces(conversation_id, created_at DESC);
 `

--- a/Nukara_Backend/internal/store/store.go
+++ b/Nukara_Backend/internal/store/store.go
@@ -23,6 +23,7 @@ type EmailCode struct {
 	Email     string
 	Purpose   string
 	Code      string
+	CreatedAt time.Time
 	ExpiresAt time.Time
 }
 
@@ -442,7 +443,20 @@ func (s *Store) SaveEmailCode(email, purpose, code string, ttl time.Duration) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.emailCodes[email+":"+purpose] = EmailCode{Email: email, Purpose: purpose, Code: code, ExpiresAt: time.Now().Add(ttl)}
+	now := time.Now()
+	s.emailCodes[email+":"+purpose] = EmailCode{Email: email, Purpose: purpose, Code: code, CreatedAt: now, ExpiresAt: now.Add(ttl)}
+}
+
+func (s *Store) GetLatestEmailCode(email, purpose string) (EmailCode, bool) {
+	email = strings.TrimSpace(email)
+	purpose = strings.TrimSpace(purpose)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.emailCodes[email+":"+purpose]
+	if !ok {
+		return EmailCode{}, false
+	}
+	return entry, true
 }
 
 func (s *Store) ValidateEmailCode(email, purpose, code string) bool {

--- a/Nukara_Backend/migrations/010_text_temporal_and_compact_ids.sql
+++ b/Nukara_Backend/migrations/010_text_temporal_and_compact_ids.sql
@@ -1,0 +1,47 @@
+-- migrations/010_text_temporal_and_compact_ids.sql
+-- Convert business-string identifiers in compact / temporal memory tables from UUID to TEXT.
+
+ALTER TABLE IF EXISTS conversation_compacts
+    ALTER COLUMN conversation_id TYPE TEXT USING conversation_id::text,
+    ALTER COLUMN until_turn_id TYPE TEXT USING until_turn_id::text;
+
+ALTER TABLE IF EXISTS persona_change_events
+    ALTER COLUMN source_turn_id TYPE TEXT USING source_turn_id::text;
+
+ALTER TABLE IF EXISTS memory_embeddings DROP CONSTRAINT IF EXISTS memory_embeddings_node_id_fkey;
+ALTER TABLE IF EXISTS memory_edges DROP CONSTRAINT IF EXISTS memory_edges_source_id_fkey;
+ALTER TABLE IF EXISTS memory_edges DROP CONSTRAINT IF EXISTS memory_edges_target_id_fkey;
+
+ALTER TABLE IF EXISTS memory_nodes
+    ALTER COLUMN id TYPE TEXT USING id::text,
+    ALTER COLUMN session_id TYPE TEXT USING session_id::text,
+    ALTER COLUMN source_turn_id TYPE TEXT USING source_turn_id::text;
+
+ALTER TABLE IF EXISTS memory_edges
+    ALTER COLUMN source_id TYPE TEXT USING source_id::text,
+    ALTER COLUMN target_id TYPE TEXT USING target_id::text;
+
+ALTER TABLE IF EXISTS memory_embeddings
+    ALTER COLUMN node_id TYPE TEXT USING node_id::text;
+
+DO $$ BEGIN
+    ALTER TABLE memory_edges
+        ADD CONSTRAINT memory_edges_source_id_fkey FOREIGN KEY (source_id) REFERENCES memory_nodes(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE memory_edges
+        ADD CONSTRAINT memory_edges_target_id_fkey FOREIGN KEY (target_id) REFERENCES memory_nodes(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE memory_embeddings
+        ADD CONSTRAINT memory_embeddings_node_id_fkey FOREIGN KEY (node_id) REFERENCES memory_nodes(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE IF EXISTS activation_traces
+    ALTER COLUMN conversation_id TYPE TEXT USING conversation_id::text,
+    ALTER COLUMN turn_id TYPE TEXT USING turn_id::text;

--- a/docs/plans/2026-03-08-auth-memory-admin-bugs-design.md
+++ b/docs/plans/2026-03-08-auth-memory-admin-bugs-design.md
@@ -1,0 +1,93 @@
+# Auth / Memory / Admin Bugs Design
+
+**Date:** 2026-03-08
+
+## Goal
+
+一次性修复三个线上问题：
+
+1. 邮箱注册阶段重复发送验证码。
+2. AgentX 对话链路中 compact / temporal memory 使用了错误的 ID 语义，导致 UUID 解析错误、对话失败、记忆图无节点。
+3. Admin 侧 provider 管理入口信息密度过低，常规 provider 测试入口缺失，需要改成更紧凑的卡牌 + expander 结构。
+
+## Confirmed Root Causes
+
+### 1. 对话与记忆 ID 语义混淆
+
+当前代码仍残留旧的 `NanobotConvID` / `nukara:user:bot:conv` 复合会话 ID 习惯。部分 AgentX 运行时入口把这个 provider-facing 会话 ID 直接传给 runtime context，而 runtime context 又会据此读取：
+
+- conversation compact
+- temporal memory recall
+- activation trace / session summary 相关节点
+
+这会把本地 conversation id 与 provider 会话 id 混为一谈。
+
+### 2. Temporal memory schema 仍把多处业务字符串 ID 建成 UUID
+
+当前 temporal memory / compact schema 把以下字段建成 UUID，但代码里实际写入的是业务字符串：
+
+- `conversation_compacts.conversation_id`
+- `memory_nodes.session_id`
+- `memory_nodes.source_turn_id`
+- `activation_traces.conversation_id`
+- `activation_traces.turn_id`
+
+同时 memory node id 代码允许 materialized id / `session-summary:*` 等字符串节点 ID，因此 DB schema 与代码模型不一致。
+
+### 3. Admin 图谱仍主要展示旧 memory_items 视角
+
+新的 temporal memory graph 已是主系统，但 admin 图谱仍主要围绕旧 `memory_items` 结构构图，所以新机器人在只产生 temporal memory node 时会看起来像“空图”。
+
+### 4. 邮件重复发送
+
+重复发送问题优先按“后端幂等 / 短冷却”修复：即使前端重复触发，也只允许短时间内产生一封有效验证码邮件，避免用户收到双邮件。
+
+## Design Decisions
+
+### A. 拆分两类会话 ID
+
+- `localConversationID`：Nukara 本地会话 ID，仅用于 store / compact / recall / trace。
+- `providerConversationID`：给 provider / legacy agent client 用的会话 ID。
+
+AgentX runtime 上下文、compact、memory recall 一律只使用 `localConversationID`。
+
+### B. 统一 temporal memory / compact 为 TEXT 语义
+
+把上述错误建模为 UUID 的业务字段改为 `TEXT`，并增加兼容迁移：
+
+- 新部署直接建正确类型。
+- 已部署实例通过 migration 将旧列转为 `TEXT`。
+
+### C. Admin memory graph 切到 temporal memory graph 主数据源
+
+Admin 图谱改为：
+
+- 节点：`memory_nodes`
+- 边：`memory_edges`
+- 辅助侧栏：recent impressions / persona changes / runtime state
+
+旧 `memory_items` 仅作为兼容信息，不再作为主图来源。
+
+### D. 邮件发送增加短冷却 / 幂等保护
+
+在 `auth/email/send` 链路增加基于 `(email, purpose)` 的短时间发送保护，避免双击 / 重试 / 双端重复触发时重复发信。
+
+### E. Admin provider 页面压缩为卡牌 + expander
+
+左侧 provider 区域改为：
+
+- 每个 provider 一张紧凑卡牌
+- 头部展示名称、状态、模式、模型、用户数
+- 展开后展示编辑表单、切换模式、连接测试、chat 测试等
+
+这样恢复常规 provider 测试能力，同时减少纵向占用。
+
+## Validation
+
+需要验证：
+
+1. 注册连续点击发送验证码，不会收到双邮件。
+2. WS / HTTP 聊天链路不再因 compact / session-summary UUID 错误失败。
+3. 新机器人完成一轮对话后，admin memory graph 能看到 temporal nodes / edges。
+4. Admin provider 页面仍可：查看、编辑、切换模式、执行测试。
+5. 前端构建与后端相关测试通过。

--- a/docs/plans/2026-03-08-auth-memory-admin-bugs-impl-plan.md
+++ b/docs/plans/2026-03-08-auth-memory-admin-bugs-impl-plan.md
@@ -1,0 +1,94 @@
+# Auth / Memory / Admin Bugs Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 修复邮箱验证码重复发送、AgentX 对话链路 compact / temporal memory ID 混淆、admin provider 页面紧凑化与测试入口恢复。
+
+**Architecture:** 将 provider-facing conversation id 与本地 conversation id 解耦；把 temporal memory / compact 中承载业务字符串的列改为 `TEXT`；admin memory graph 改为读取 temporal memory graph；邮箱验证码发送增加后端冷却保护；admin provider 页面改为卡牌 + expander。
+
+**Tech Stack:** Go, PostgreSQL, Vue 3, Pinia, Vite
+
+---
+
+### Task 1: Cover current failures with tests
+
+**Files:**
+- Modify: `Nukara_Backend/internal/api/email_auth_test.go`
+- Modify: `Nukara_Backend/internal/api/runtime_context_test.go`
+- Modify: `Nukara_Backend/internal/admin/memory_graph_handler_test.go`
+- Create/Modify: targeted store tests for temporal schema compatibility if needed
+
+**Steps:**
+1. Add failing test for duplicate email send suppression.
+2. Add failing test proving runtime context uses local conversation id for compact lookup.
+3. Add failing test proving temporal node IDs / session summary IDs may be non-UUID strings.
+4. Add failing test proving admin graph includes temporal memory nodes.
+
+### Task 2: Fix backend ID semantics and schema
+
+**Files:**
+- Modify: `Nukara_Backend/internal/api/runtime_context.go`
+- Modify: `Nukara_Backend/internal/api/runtime_adapter.go`
+- Modify: `Nukara_Backend/internal/api/chat_flow.go`
+- Modify: `Nukara_Backend/internal/api/emotion_tracker.go`
+- Modify: `Nukara_Backend/internal/api/bot_profile.go`
+- Modify: `Nukara_Backend/internal/api/self_cognition_summary.go` if needed
+- Modify: `Nukara_Backend/internal/store/postgres_store.go`
+- Modify: `Nukara_Backend/internal/store/postgres_temporal_memory_graph.go`
+- Add migration(s) under `Nukara_Backend/migrations`
+
+**Steps:**
+1. Introduce explicit local conversation id usage in runtime context path.
+2. Keep provider-facing conversation id only for provider transport.
+3. Change compact / temporal memory string-ID columns to `TEXT`.
+4. Add schema migration for existing DBs.
+5. Run targeted tests.
+
+### Task 3: Fix duplicate email sending
+
+**Files:**
+- Modify: `Nukara_Backend/internal/api/server.go`
+- Modify: `Nukara_Backend/internal/store/interface.go` if needed
+- Modify: `Nukara_Backend/internal/store/store.go` / postgres store if persistent cooldown is needed
+
+**Steps:**
+1. Implement short cooldown / idempotency check on `(email, purpose)`.
+2. Return success message without second SMTP send when within cooldown.
+3. Keep existing login/register validation unchanged.
+4. Run auth tests.
+
+### Task 4: Switch admin graph to temporal memory graph source
+
+**Files:**
+- Modify: `Nukara_Backend/internal/admin/memory_graph_handler.go`
+- Modify: `Nukara_Backend/internal/admin/memory_graph_handler_test.go`
+
+**Steps:**
+1. Query temporal nodes / edges as primary graph source.
+2. Preserve side panels for recent impressions / persona changes.
+3. Ensure new bots with temporal nodes render non-empty graph.
+4. Run admin handler tests.
+
+### Task 5: Compact admin provider UI
+
+**Files:**
+- Modify: `Nukara_Admin_Web/src/App.vue`
+- Modify: `Nukara_Admin_Web/src/style.css`
+- Modify tests under `Nukara_Admin_Web/tests` if needed
+
+**Steps:**
+1. Refactor provider list into compact card + expander layout.
+2. Restore visible provider edit/test actions inside expanded section.
+3. Keep switching, chat test, and save flows intact.
+4. Build admin frontend.
+
+### Task 6: Verify
+
+**Files:**
+- No source changes unless fixing local regressions
+
+**Steps:**
+1. Run targeted Go tests for auth, runtime context, admin memory graph, temporal memory graph.
+2. Run admin frontend build.
+3. If needed, run targeted chat / full-stack smoke.
+4. Summarize any remaining manual validation items.


### PR DESCRIPTION
## Summary
- fix text-based temporal memory and compact IDs to avoid UUID parsing failures for `session-summary:*` and provider conversation IDs
- suppress duplicate email verification sends with cooldown and in-process serialization
- refactor admin provider management into compact cards with expanders while preserving edit, connectivity test, chat test, and activation actions
- make admin memory graph prefer temporal graph data for new bots

## Validation
- `go test ./internal/api -run 'Test(RuntimeContextIncludesRuntimeStateAndPromises|NewTurnRequestSeparatesProviderConversationIDFromLocalConversationID|EmailAuthSendRequiresSMTPConfig|EmailAuthRegisterUsesEmailCode|EmailAuthLoginUsesEmailCode|EmailAuthSendSuppressesImmediateDuplicateEmails)$' -count=1`
- `go test ./internal/admin ./internal/agentx/memorygraph ./internal/store -count=1`
- `npm run build`
- `node tests/provider-api.spec.mjs`
- `node tests/memory-graph-layout.spec.mjs`
- `bash scripts/verify_redeploy_safe_defaults.sh`
- `bash scripts/verify_redeploy_env_passthrough.sh`
- `bash scripts/verify_incremental_deploy_guards.sh`
- `bash scripts/verify_deploy_bash_compat.sh`